### PR TITLE
Logical Switch Port additional details

### DIFF
--- a/bms-ansible-nsx/dhcp_config.yml
+++ b/bms-ansible-nsx/dhcp_config.yml
@@ -8,8 +8,8 @@
   tasks:
     - name: config underlay mode
       set_fact:
-        config_mode: "config_mode=dhcp"
-        underlay_mode: "false"
+        config_mode: 'config_mode=dhcp'
+        underlay_mode: 'false'
     - import_tasks: system/get_os_type.yml
     - import_tasks: config/tn_uuid.yml
     - import_tasks: lsp/vif_id.yml

--- a/bms-ansible-nsx/dhcp_config.yml
+++ b/bms-ansible-nsx/dhcp_config.yml
@@ -15,10 +15,10 @@
     - import_tasks: lsp/vif_id.yml
     - import_tasks: vif/int_br_name.yml
     - import_tasks: validation/vif_id_check.yml
+    - import_tasks: config/app_intf_name.yml
     - import_tasks: lsp/create_lsp.yml
     - import_tasks: config/bms_config.yml
     - import_tasks: config/config.yml
-    - import_tasks: config/app_intf_name.yml
     - import_tasks: vif/create_vif.yml
     - import_tasks: vif/attach_vif.yml
     - import_tasks: route/route.yml

--- a/bms-ansible-nsx/migrate.yml
+++ b/bms-ansible-nsx/migrate.yml
@@ -8,7 +8,7 @@
   tasks:
     - name: config underlay mode
       set_fact:
-        underlay_mode: "true"
+        underlay_mode: 'true'
         FQDN: false
     - import_tasks: system/get_os_type.yml
     - import_tasks: config/tn_uuid.yml

--- a/bms-ansible-nsx/migrate.yml
+++ b/bms-ansible-nsx/migrate.yml
@@ -18,10 +18,10 @@
     - import_tasks: vif/int_br_name.yml
     - import_tasks: validation/vif_id_check.yml
     - import_tasks: validation/migration_input_check.yml
+    - import_tasks: config/app_intf_name.yml
     - import_tasks: lsp/create_lsp.yml
     - import_tasks: config/bms_config.yml
       when: not FQDN
-    - import_tasks: config/app_intf_name.yml
     - name: generate config file
       block:
         - name: remove old config file

--- a/bms-ansible-nsx/static_config.yml
+++ b/bms-ansible-nsx/static_config.yml
@@ -16,10 +16,10 @@
     - import_tasks: vif/int_br_name.yml
     - import_tasks: validation/vif_id_check.yml
     - import_tasks: validation/static_input_check.yml
+    - import_tasks: config/app_intf_name.yml
     - import_tasks: lsp/create_lsp.yml
     - import_tasks: config/bms_config.yml
     - import_tasks: config/config.yml
-    - import_tasks: config/app_intf_name.yml
     - import_tasks: vif/create_vif.yml
     - name: create bm dir
       file:

--- a/bms-ansible-nsx/static_config.yml
+++ b/bms-ansible-nsx/static_config.yml
@@ -8,8 +8,8 @@
   tasks:
     - name: config underlay mode
       set_fact:
-        config_mode: "config_mode=static"
-        underlay_mode: "false"
+        config_mode: 'config_mode=static'
+        underlay_mode: 'false'
     - import_tasks: system/get_os_type.yml
     - import_tasks: config/tn_uuid.yml
     - import_tasks: lsp/vif_id.yml

--- a/bms-ansible-nsx/templates/create_lsp.json.j2
+++ b/bms-ansible-nsx/templates/create_lsp.json.j2
@@ -1,4 +1,5 @@
 {
+  "display_name": "{{ ansible_hostname }}/{{ app_intf_name }}@{{ tn_uuid.stdout }}",
   "logical_switch_id": "{{ ls_id }}",
   "attachment": {
     "attachment_type": "VIF",
@@ -11,6 +12,12 @@
     }
   },
   "address_bindings": [],
-  "admin_state": "UP"
+  "admin_state": "UP",
+  "tags": [
+    {
+        "scope": "bm/os_type",
+        "tag": "{{ os_type.stdout }}"
+    }
+  ]
 }
 


### PR DESCRIPTION
Minor changes to add a display name to the Application Interface Logical Switch Port that is created.

Also, apply a tag to the port that defines the OS type, and some minor YAML formatting changes.